### PR TITLE
Add Color Channel Manipulation & Swapping filter

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -1,6 +1,7 @@
 import numpy as np
 from brightness_helpers import get_brightness_factor
 from edge_helpers import get_sobel_kernels, apply_convolution, normalize_edges
+import cv2
 
 def apply_brightness(image, level=0):
     """Apply brightness adjustment with specified level"""
@@ -174,3 +175,49 @@ def apply_edge_detection(image, sensitivity=1.0, direction='both'):
     
     # Convert back to 3-channel image
     return np.stack([edges, edges, edges], axis=-1)
+
+def apply_channel_swap(image, mode='rgb'):
+    """
+    Swap or manipulate color channels of an image
+    
+    Args:
+        image: Input image (numpy array)
+        mode: Channel manipulation mode:
+            'rgb' - Original (no change)
+            'rbg' - Swap red and blue
+            'grb' - Swap green and red
+            'gbr' - Green to blue, blue to red, red to green
+            'brg' - Blue to red, red to green, green to blue
+            'bgr' - Reverse order (OpenCV default)
+            'r' - Keep only red channel
+            'g' - Keep only green channel
+            'b' - Keep only blue channel
+    
+    Returns:
+        Image with modified color channels (numpy array)
+    """
+    if mode == 'rgb':
+        return image.copy()
+    
+    # Split channels
+    b, g, r = cv2.split(image)
+    
+    # Apply different channel combinations
+    if mode == 'rbg':
+        return cv2.merge((g, b, r))
+    elif mode == 'grb':
+        return cv2.merge((b, r, g))
+    elif mode == 'gbr':
+        return cv2.merge((g, r, b))
+    elif mode == 'brg':
+        return cv2.merge((r, b, g))
+    elif mode == 'bgr':
+        return cv2.merge((r, g, b))
+    elif mode == 'r':
+        return cv2.merge(( np.zeros_like(r), np.zeros_like(r), r))
+    elif mode == 'g':
+        return cv2.merge((np.zeros_like(g), g, np.zeros_like(g)))
+    elif mode == 'b':
+        return cv2.merge((b, np.zeros_like(b), np.zeros_like(b)))
+    else:
+        raise ValueError(f"Unknown channel mode: {mode}")

--- a/main.py
+++ b/main.py
@@ -1,12 +1,11 @@
 import os
 import time
-from filters import apply_brightness, apply_all_brightness_levels, apply_grayscale, add_gaussian_noise, add_salt_pepper_noise, apply_edge_detection
+from filters import apply_brightness, apply_all_brightness_levels, apply_grayscale, add_gaussian_noise, add_salt_pepper_noise, apply_edge_detection,unsharp_mask
 from brightness_helpers import get_brightness_description
 from noiseRemovalFilter import remove_noise
 from InvertColorFilter import apply_invert
 import utils
-from noise_filter_helper import smooth_image_with_gaussian_blur, smooth_image_with_gaussian_blur, \
-    remove_noise_with_median_filter
+from noise_filter_helper import smooth_image_with_gaussian_blur, remove_noise_with_median_filter
 
 
 def load_image():
@@ -96,6 +95,22 @@ def apply_gaussian_noise_filter(current_image, output_dir):
     except ValueError:
         print("Please enter a value between 0.0 and 1.0.")
 
+def apply_noise_then_sharpen(current_image, output_dir):
+    sharpened = unsharp_mask(
+        current_image,
+        ksize=(5, 5),
+        sigma=1.0,
+        amount=1.5,
+        threshold=10
+    )
+    sharp_filename = f"noise_sharpen.jpg"
+    sharp_path = os.path.join(output_dir, sharp_filename)
+    utils.save_image(sharpened, sharp_path)
+    print(f"✨ Sharpened image saved to {sharp_path}")
+
+    # 3) Display comparison
+    utils.display_comparison(current_image, sharpened,
+                             title=f"Noise  → Sharpen ")
 
 def apply_salt_pepper_noise_filter(current_image, output_dir):
     """Apply Salt and Pepper noise with user-specified intensity"""
@@ -272,6 +287,7 @@ def show_main_menu():
     print("9. Noise Removal Tool")
     print("10. Apply invert color filter")
     print("11. Apply edge detection filter")
+    print("12. Add noise then sharpen")
     print("0. Exit")
     return input("Choose an option: ").strip()
 
@@ -313,6 +329,8 @@ def main():
             apply_invert_filter(current_image, output_dir)
         elif choice == "11":
             apply_edge_detection_filter(current_image, output_dir)
+        elif choice == "12":
+            apply_noise_then_sharpen(current_image, output_dir)
         elif choice == "0":
             print("Exiting...")
             time.sleep(1)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import os
 import time
-from filters import apply_brightness, apply_all_brightness_levels, apply_grayscale, add_gaussian_noise, add_salt_pepper_noise, apply_edge_detection,unsharp_mask
+from filters import apply_brightness, apply_all_brightness_levels, apply_grayscale, add_gaussian_noise, add_salt_pepper_noise, apply_edge_detection,unsharp_mask,apply_channel_swap
 from brightness_helpers import get_brightness_description
 from noiseRemovalFilter import remove_noise
 from InvertColorFilter import apply_invert
@@ -271,6 +271,38 @@ def apply_edge_detection_filter(current_image, output_dir):
     except ValueError:
         print("Please enter valid numbers for sensitivity.")
 
+def apply_channel_swap_filter(current_image, output_dir):
+    """Apply channel swap/manipulation filter"""
+    print("\nAvailable channel modes:")
+    print("1. RGB (original)")
+    print("2. RBG (swap blue/green)")
+    print("3. GRB (swap green/red)")
+    print("4. GBR (green→blue, blue→red, red→green)")
+    print("5. BRG (blue→red, red→green, green→blue)")
+    print("6. BGR (reverse order)")
+    print("7. Red channel only")
+    print("8. Green channel only")
+    print("9. Blue channel only")
+    
+    choice = input("Select mode (1-9): ").strip()
+    
+    mode_map = {
+        '1': 'rgb', '2': 'rbg', '3': 'grb',
+        '4': 'gbr', '5': 'brg', '6': 'bgr',
+        '7': 'r', '8': 'g', '9': 'b'
+    }
+    
+    if choice not in mode_map:
+        print("Invalid option.")
+        return
+        
+    result = apply_channel_swap(current_image, mode_map[choice])
+    
+    # Save and display
+    output_path = os.path.join(output_dir, f"channel_{mode_map[choice]}.jpg")
+    utils.save_image(result, output_path)
+    utils.display_comparison(current_image, result, 
+                           f"Channel {mode_map[choice].upper()}")
 
 
 def show_main_menu():
@@ -288,6 +320,7 @@ def show_main_menu():
     print("10. Apply invert color filter")
     print("11. Apply edge detection filter")
     print("12. Add noise then sharpen")
+    print("13. Channel Manipulation & Swapping")
     print("0. Exit")
     return input("Choose an option: ").strip()
 
@@ -331,6 +364,8 @@ def main():
             apply_edge_detection_filter(current_image, output_dir)
         elif choice == "12":
             apply_noise_then_sharpen(current_image, output_dir)
+        elif choice == "13":
+            apply_channel_swap_filter(current_image, output_dir)
         elif choice == "0":
             print("Exiting...")
             time.sleep(1)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -5,7 +5,7 @@ import io
 
 from filters import (
     apply_brightness, apply_all_brightness_levels, apply_grayscale,
-    add_gaussian_noise, add_salt_pepper_noise, apply_edge_detection
+    add_gaussian_noise, add_salt_pepper_noise, apply_edge_detection,apply_channel_swap
 )
 from brightness_helpers import get_brightness_description
 from noiseRemovalFilter import remove_noise
@@ -37,7 +37,8 @@ if uploaded_file:
         "Denoise (Median)",
         "Noise Removal Tool",
         "Invert Colors",
-        "Edge Detection"
+        "Edge Detection",
+        "Manipulation & Swapping"
     ])
 
     result = img.copy()
@@ -94,6 +95,11 @@ if uploaded_file:
         sensitivity = st.sidebar.slider("Sensitivity", 0.1, 2.0, 1.0)
         result = apply_edge_detection(img, sensitivity, edge_dir)
         out_filename = f"edges_{edge_dir}_{sensitivity:.1f}.jpg"
+
+    elif operation == "Manipulation & Swapping":
+        mode_map = st.sidebar.selectbox("Available channel modes:", ["RGB (original)", "RBG (swap red/blue)", "GRB (swap green/red)", "GBR (green→blue, blue→red, red→green)", "BRG (blue→red, red→green, green→blue)", "BGR (reverse order)", "Red channel only", "Green channel only", "Blue channel only"])
+        result = apply_channel_swap(img, mode_map)
+        out_filename = "Swapping.jpg"
 
     else:
         st.info("Choose an operation from the sidebar to process your image!")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -38,7 +38,6 @@ if uploaded_file:
         "Noise Removal Tool",
         "Invert Colors",
         "Edge Detection",
-        "Manipulation & Swapping"
     ])
 
     result = img.copy()
@@ -95,11 +94,6 @@ if uploaded_file:
         sensitivity = st.sidebar.slider("Sensitivity", 0.1, 2.0, 1.0)
         result = apply_edge_detection(img, sensitivity, edge_dir)
         out_filename = f"edges_{edge_dir}_{sensitivity:.1f}.jpg"
-
-    elif operation == "Manipulation & Swapping":
-        mode_map = st.sidebar.selectbox("Available channel modes:", ["RGB (original)", "RBG (swap red/blue)", "GRB (swap green/red)", "GBR (green→blue, blue→red, red→green)", "BRG (blue→red, red→green, green→blue)", "BGR (reverse order)", "Red channel only", "Green channel only", "Blue channel only"])
-        result = apply_channel_swap(img, mode_map)
-        out_filename = "Swapping.jpg"
 
     else:
         st.info("Choose an operation from the sidebar to process your image!")


### PR DESCRIPTION
    Swap or manipulate color channels of an image
    
    Args:
        image: Input image (numpy array)
        mode: Channel manipulation mode:
            'rgb' - Original (no change)
            'rbg' - Swap red and blue
            'grb' - Swap green and red
            'gbr' - Green to blue, blue to red, red to green
            'brg' - Blue to red, red to green, green to blue
            'bgr' - Reverse order (OpenCV default)
            'r' - Keep only red channel
            'g' - Keep only green channel
            'b' - Keep only blue channel
    
    Returns:
        Image with modified color channels (numpy array)